### PR TITLE
[FEAT] Add district selection flow for date recommendations - PIT-532

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,9 @@ import AuthBootstrap from './app/providers/AuthBootstrap';
 import { CoupleRoomModal } from './pages/CoupleRoomPage/CoupleRoomModal';
 import { CoupleCodeRoom } from './pages/CoupleRoomPage/CoupleCodeRoom';
 import { CreateDiaryPage } from './pages/DiaryPage/CreateDiaryPage';
+import { DistrictModal } from './pages/DistrictPage/DistrictModal';
+import { DistrictChoose } from './pages/DistrictPage/DistrictChoose';
+import { DistrictCheck } from './pages/DistrictPage/DistrictCheck';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import DataBootstrap from './app/providers/DataBootstrap';
@@ -41,6 +44,10 @@ function App() {
               <Route path="create" element={<CreateCoupleRoom />} />
               <Route path="create/:id" element={<CoupleCodeRoom />} />
               <Route path="enter" element={<EnterCoupleRoom />} />
+            </Route>
+            <Route path="district" element={<DistrictModal />}>
+              <Route path="choose" element={<DistrictChoose />} />
+              <Route path="check" element={<DistrictCheck />} />
             </Route>
           </Route>
           <Route path="/options" element={<OptionsPage />} />

--- a/src/features/mypage/api.ts
+++ b/src/features/mypage/api.ts
@@ -5,5 +5,8 @@ export const mypageApi = {
   putMypage: (data: any) => api.put('/api/auth/profile', data),
   deleteCouple: () => api.delete("/api/couples/cancel"),
   putCoupleHome: (data: any) => api.put('/api/couples', data),
+  getDistrictLock: () => api.get('/api/districts/lock-status'),
+  unlockDistrict: (districtId: string) => api.post(`/api/districts/${districtId}/unlock`),
+  confirmDistrictSelection: (districtIds: string[]) => api.post('/api/auth/confirm-districts', { districtIds }),
 };
 

--- a/src/features/mypage/components/DistrictLock.tsx
+++ b/src/features/mypage/components/DistrictLock.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faLock, faUnlock, faKey, faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons';
+import { mypageApi } from '../api';
+import { DistrictInfo, DistrictLockData, CityData } from '../types';
+import { Spinner } from '../../../shared/ui/spinner';
+import { toast } from 'react-toastify';
+
+export const DistrictLock = () => {
+  const [selectedCity, setSelectedCity] = useState<string>('서울시');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [unlockingDistricts, setUnlockingDistricts] = useState<Set<string>>(new Set());
+
+  // 지역구 잠금 상태 조회
+  const { data: districtData, isLoading, isError, refetch } = useQuery<DistrictLockData>({
+    queryKey: ['districtLock'],
+    queryFn: async () => {
+      // 실제 API 호출 대신 mock 데이터 사용
+      const mockData = await import('../mocks/districtLockMock.json');
+      return mockData.data;
+    },
+  });
+
+  // 지역구 잠금 해제 mutation
+  const unlockDistrictMutation = useMutation({
+    mutationFn: (districtId: string) => mypageApi.unlockDistrict(districtId),
+    onSuccess: (_, districtId) => {
+      toast.success('지역구 잠금이 해제되었습니다!');
+      setUnlockingDistricts(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(districtId);
+        return newSet;
+      });
+      refetch();
+    },
+    onError: (_, districtId) => {
+      toast.error('잠금 해제에 실패했습니다.');
+      setUnlockingDistricts(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(districtId);
+        return newSet;
+      });
+    },
+  });
+
+  // 지역구 잠금 해제 핸들러
+  const handleUnlockDistrict = (district: DistrictInfo) => {
+    const answer = window.confirm(`${district.name}의 잠금을 해제하시겠습니까?`);
+    if (answer) {
+      setUnlockingDistricts(prev => new Set(prev).add(district.id));
+      unlockDistrictMutation.mutate(district.id);
+    }
+  };
+
+  // 현재 선택된 도시 데이터
+  const currentCityData = districtData?.cities.find(city => city.cityName === selectedCity);
+
+  // 검색 필터링 및 정렬 (잠금 해제된 것 먼저)
+  const filteredDistricts = currentCityData?.districts
+    .filter(district =>
+      district.name.toLowerCase().includes(searchTerm.toLowerCase())
+    )
+    .sort((a, b) => {
+      // 잠금 해제된 것(isLocked: false)이 먼저 오도록 정렬
+      if (a.isLocked === b.isLocked) return 0;
+      return a.isLocked ? 1 : -1;
+    }) || [];
+
+  if (isLoading) return <Spinner />;
+  if (isError) return <div className="flex justify-center items-center text-red-500">정보를 불러오는데 실패했습니다.</div>;
+
+  return (
+    <div className="h-full w-full p-8 py-2 group">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-800">자치구 잠금 시스템</h1>
+        <div className="flex items-center gap-2">
+          <FontAwesomeIcon icon={faKey} className="w-6 h-6 text-primary" />
+          <span className="text-sm text-gray-600">보유 키: {districtData?.totalKeys}개</span>
+        </div>
+      </div>
+
+      {/* 도시 탭 메뉴 */}
+      <div className="flex gap-1 mb-6 bg-gray-100 rounded-lg p-1">
+        <button
+          onClick={() => setSelectedCity('서울시')}
+          className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
+            selectedCity === '서울시'
+              ? 'bg-white text-primary shadow-sm'
+              : 'text-gray-600 hover:text-gray-800'
+          }`}
+        >
+          서울시
+        </button>
+        <button
+          className="px-4 py-2 rounded-md text-sm font-medium text-gray-400 cursor-not-allowed"
+          disabled
+        >
+          (추후 추가 예정)
+        </button>
+      </div>
+
+      {/* 요약 정보 */}
+      <div className="bg-white rounded-lg p-4 mb-6 shadow-sm border border-gray-200">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold text-gray-800">{selectedCity} 총 자치구: {currentCityData?.totalDistricts}개</h2>
+        </div>
+        <div className="flex gap-6">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 bg-orange-500 rounded-full"></div>
+            <span className="text-sm text-gray-600">잠금: {currentCityData?.lockedDistricts}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 bg-green-500 rounded-full"></div>
+            <span className="text-sm text-gray-600">해제: {currentCityData?.unlockedDistricts}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 검색바 */}
+      <div className="mb-6">
+        <input
+          type="text"
+          placeholder="지역구 검색..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full h-12 px-4 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-pink-200 focus:border-transparent transition-all duration-200"
+        />
+      </div>
+
+      {/* 지역구 그리드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 max-h-96 overflow-y-auto">
+        {filteredDistricts.map((district) => (
+          <div
+            key={district.id}
+            className={`p-4 rounded-lg border transition-all duration-200 hover:shadow-md ${
+              district.isLocked
+                ? 'bg-orange-50 border-orange-200 hover:bg-orange-100'
+                : 'bg-green-50 border-green-200 hover:bg-green-100'
+            }`}
+          >
+            <div className="flex flex-col items-center text-center">
+              {/* 잠금 아이콘 */}
+              <div className={`w-12 h-12 rounded-full flex items-center justify-center mb-3 ${
+                district.isLocked ? 'bg-orange-100' : 'bg-green-100'
+              }`}>
+                <FontAwesomeIcon
+                  icon={district.isLocked ? faLock : faUnlock}
+                  className={`w-6 h-6 ${
+                    district.isLocked ? 'text-orange-600' : 'text-green-600'
+                  }`}
+                />
+              </div>
+              
+              {/* 지역구 정보 */}
+              <h3 className="font-medium text-gray-800 mb-1">{district.name}</h3>
+              <p className="text-xs text-gray-600 mb-3 line-clamp-2">{district.description}</p>
+              
+              {/* 잠금 해제 버튼 */}
+              {district.isLocked ? (
+                <button
+                  onClick={() => handleUnlockDistrict(district)}
+                  disabled={unlockingDistricts.has(district.id)}
+                  className="w-full px-3 py-2 rounded-md text-sm font-medium bg-primary text-white hover:bg-primary/80 disabled:opacity-50 transition-all duration-200"
+                >
+                  {unlockingDistricts.has(district.id) ? '해제 중...' : '잠금 해제'}
+                </button>
+              ) : (
+                <div className="w-full px-3 py-2 rounded-md text-sm font-medium bg-green-100 text-green-700 text-center">
+                  잠금 해제됨
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 빈 상태 */}
+      {filteredDistricts.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          <FontAwesomeIcon icon={faMapMarkerAlt} className="w-12 h-12 mx-auto mb-4 text-gray-300" />
+          <p>검색 결과가 없습니다.</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/mypage/index.ts
+++ b/src/features/mypage/index.ts
@@ -1,0 +1,5 @@
+export { Profile } from './components/Profile';
+export { CoupleHome } from './components/CoupleHome';
+export { DistrictLock } from './components/DistrictLock';
+export { mypageApi } from './api';
+export type { DistrictInfo, DistrictLockData } from './types';

--- a/src/features/mypage/mocks/districtLockMock.json
+++ b/src/features/mypage/mocks/districtLockMock.json
@@ -1,0 +1,166 @@
+{
+  "success": true,
+  "data": {
+    "totalKeys": 15,
+    "cities": [
+      {
+        "cityName": "서울시",
+        "totalDistricts": 25,
+        "lockedDistricts": 20,
+        "unlockedDistricts": 5,
+        "districts": [
+          {
+            "id": "gangnam",
+            "name": "강남구",
+            "isLocked": false,
+            "description": "서울의 중심가, 강남역 일대"
+          },
+          {
+            "id": "seocho",
+            "name": "서초구",
+            "isLocked": false,
+            "description": "강남의 중심, 서초동과 반포동"
+          },
+          {
+            "id": "mapo",
+            "name": "마포구",
+            "isLocked": false,
+            "description": "홍대, 이대, 연세대가 있는 젊은 도시"
+          },
+          {
+            "id": "jongno",
+            "name": "종로구",
+            "isLocked": false,
+            "description": "경복궁과 인사동이 있는 역사적 중심가"
+          },
+          {
+            "id": "jung",
+            "name": "중구",
+            "isLocked": false,
+            "description": "명동과 남대문이 있는 서울의 중심"
+          },
+          {
+            "id": "gangdong",
+            "name": "강동구",
+            "isLocked": true,
+            "description": "한강과 접한 동부 지역"
+          },
+          {
+            "id": "gangbuk",
+            "name": "강북구",
+            "isLocked": true,
+            "description": "북한산 기슭의 조용한 주거지역"
+          },
+          {
+            "id": "gangseo",
+            "name": "강서구",
+            "isLocked": true,
+            "description": "김포공항과 가까운 서부 지역"
+          },
+          {
+            "id": "gwanak",
+            "name": "관악구",
+            "isLocked": true,
+            "description": "서울대학교가 위치한 지역"
+          },
+          {
+            "id": "gwangjin",
+            "name": "광진구",
+            "isLocked": true,
+            "description": "건국대학교와 한강이 만나는 곳"
+          },
+          {
+            "id": "guro",
+            "name": "구로구",
+            "isLocked": true,
+            "description": "구로디지털단지가 있는 지역"
+          },
+          {
+            "id": "geumcheon",
+            "name": "금천구",
+            "isLocked": true,
+            "description": "서울의 남서부 끝자락"
+          },
+          {
+            "id": "nowon",
+            "name": "노원구",
+            "isLocked": true,
+            "description": "북한산과 도봉산 사이의 지역"
+          },
+          {
+            "id": "dobong",
+            "name": "도봉구",
+            "isLocked": true,
+            "description": "도봉산이 있는 북부 지역"
+          },
+          {
+            "id": "dongdaemun",
+            "name": "동대문구",
+            "isLocked": true,
+            "description": "동대문 시장과 청계천이 있는 지역"
+          },
+          {
+            "id": "dongjak",
+            "name": "동작구",
+            "isLocked": true,
+            "description": "한강과 남산이 보이는 지역"
+          },
+          {
+            "id": "seodaemun",
+            "name": "서대문구",
+            "isLocked": true,
+            "description": "서대문형무소와 독립문이 있는 역사적 지역"
+          },
+          {
+            "id": "seongdong",
+            "name": "성동구",
+            "isLocked": true,
+            "description": "성수동과 한강이 만나는 지역"
+          },
+          {
+            "id": "seongbuk",
+            "name": "성북구",
+            "isLocked": true,
+            "description": "한성대와 고려대가 있는 지역"
+          },
+          {
+            "id": "songpa",
+            "name": "송파구",
+            "isLocked": true,
+            "description": "롯데월드타워와 올림픽공원이 있는 지역"
+          },
+          {
+            "id": "yangcheon",
+            "name": "양천구",
+            "isLocked": true,
+            "description": "목동과 신정동이 있는 서부 지역"
+          },
+          {
+            "id": "yeongdeungpo",
+            "name": "영등포구",
+            "isLocked": true,
+            "description": "여의도와 한강이 만나는 지역"
+          },
+          {
+            "id": "yongsan",
+            "name": "용산구",
+            "isLocked": true,
+            "description": "남산과 한강이 만나는 중심가"
+          },
+          {
+            "id": "eunpyeong",
+            "name": "은평구",
+            "isLocked": true,
+            "description": "북한산 기슭의 조용한 주거지역"
+          },
+          {
+            "id": "jungnang",
+            "name": "중랑구",
+            "isLocked": true,
+            "description": "동부의 조용한 주거지역"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/features/mypage/types.ts
+++ b/src/features/mypage/types.ts
@@ -1,0 +1,19 @@
+export interface DistrictInfo {
+  id: string;
+  name: string;
+  isLocked: boolean;
+  description?: string;
+}
+
+export interface CityData {
+  cityName: string;
+  totalDistricts: number;
+  lockedDistricts: number;
+  unlockedDistricts: number;
+  districts: DistrictInfo[];
+}
+
+export interface DistrictLockData {
+  totalKeys: number;
+  cities: CityData[];
+}

--- a/src/pages/CoupleRoomPage/EnterCoupleRoom.tsx
+++ b/src/pages/CoupleRoomPage/EnterCoupleRoom.tsx
@@ -69,7 +69,7 @@ export const EnterCoupleRoom = () => {
       
       if (result.status === 'success') {
         toast.success('커플 인증이 완료되었습니다');
-        navigate('/home');
+        navigate('/home/district/choose');
       } else {
         setIsError(true);
         throw new Error('커플 인증에 실패했습니다');

--- a/src/pages/DistrictPage/DistrictCheck.tsx
+++ b/src/pages/DistrictPage/DistrictCheck.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+import { useDistrictStore } from '../../shared/store/district.store';
+import { mypageApi } from '../../features/mypage/api';
+import { toast } from 'react-toastify';
+import { Spinner } from '../../shared/ui/spinner';
+
+export const DistrictCheck = () => {
+  const navigate = useNavigate();
+  const { selectedDistricts, clearSelectedDistricts } = useDistrictStore();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 지역구 선택 확인 API 호출
+  const confirmDistrictMutation = useMutation({
+    mutationFn: async (districtIds: string[]) => {
+      // 임시 API 엔드포인트 - 실제로는 POST /api/auth/confirm-districts 등으로 변경
+      const response = await mypageApi.confirmDistrictSelection(districtIds);
+      return response;
+    },
+    onSuccess: () => {
+      toast.success('지역구 선택이 완료되었습니다!');
+      clearSelectedDistricts();
+      navigate('/home');
+    },
+    onError: (error: any) => {
+      console.error('지역구 선택 확인 실패:', error);
+      toast.error('지역구 선택 확인에 실패했습니다.');
+      setIsSubmitting(false);
+    },
+  });
+
+  const handleConfirm = async () => {
+    if (selectedDistricts.length !== 2) {
+      toast.error('2개의 자치구를 선택해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    const districtIds = selectedDistricts.map(district => district.id);
+    confirmDistrictMutation.mutate(districtIds);
+  };
+
+  const handleBack = () => {
+    navigate('/home/district/choose');
+  };
+
+  if (selectedDistricts.length === 0) {
+    return (
+      <div className="flex items-center justify-center w-full h-full">
+        <div className="h-[800px] w-[700px] bg-[#DED6D6] border-gray-300 border rounded-2xl p-4 py-16 flex flex-col gap-4 justify-center items-center">
+          <h1 className="text-2xl font-bold text-gray-800">선택된 자치구가 없습니다</h1>
+          <p className="text-gray-600">자치구를 다시 선택해주세요.</p>
+          <button
+            onClick={handleBack}
+            className="w-[220px] h-[44px] bg-primary text-white rounded-md hover:bg-primary/80 transition-all duration-200"
+          >
+            자치구 선택하기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center w-full h-full">
+      <div className="h-[800px] w-[700px] bg-[#DED6D6] border-gray-300 border rounded-2xl p-4 py-16 flex flex-col gap-4 justify-center items-center">
+        <h1 className="text-2xl font-bold text-gray-800">데이트 지역 확인</h1>
+        <p className="text-gray-600 text-center">다음 2개의 자치구에서 데이트 코스를 추천받으시겠습니까?</p>
+        
+        {/* 선택된 자치구 목록 */}
+        <div className="w-full max-w-md space-y-4">
+          {selectedDistricts.map((district, index) => (
+            <div
+              key={district.id}
+              className="bg-white border border-gray-300 rounded-lg p-4 flex items-center gap-3"
+            >
+              <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
+                <FontAwesomeIcon 
+                  icon={faCheck} 
+                  className="w-5 h-5 text-primary" 
+                />
+              </div>
+              <div className="flex-1">
+                <h3 className="font-medium text-gray-800">{district.name}</h3>
+                {district.description && (
+                  <p className="text-sm text-gray-600">{district.description}</p>
+                )}
+              </div>
+              <div className="w-6 h-6 bg-primary rounded-full flex items-center justify-center">
+                <span className="text-white text-sm font-bold">{index + 1}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* 확인 메시지 */}
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 w-full max-w-md">
+          <div className="flex items-center gap-2">
+            <FontAwesomeIcon icon={faCheck} className="w-5 h-5 text-blue-600" />
+            <p className="text-sm text-blue-800">
+              선택한 2개 자치구를 기반으로 맞춤형 데이트 코스를 추천해드립니다.
+            </p>
+          </div>
+        </div>
+
+        {/* 버튼 그룹 */}
+        <div className="flex gap-4 w-full max-w-md">
+          <button
+            onClick={handleBack}
+            disabled={isSubmitting}
+            className="flex-1 h-[44px] bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400 disabled:opacity-50 transition-all duration-200 flex items-center justify-center gap-2"
+          >
+            <FontAwesomeIcon icon={faArrowLeft} className="w-4 h-4" />
+            다시 선택
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={isSubmitting}
+            className="flex-1 h-[44px] bg-primary text-white rounded-md hover:bg-primary/80 disabled:opacity-50 transition-all duration-200 flex items-center justify-center gap-2"
+          >
+            {isSubmitting ? (
+              <>
+                <Spinner />
+                <span>확인 중...</span>
+              </>
+            ) : (
+              <>
+                <FontAwesomeIcon icon={faCheck} className="w-4 h-4" />
+                <span>확인</span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/DistrictPage/DistrictChoose.tsx
+++ b/src/pages/DistrictPage/DistrictChoose.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMapMarkerAlt, faCheck } from '@fortawesome/free-solid-svg-icons';
+import { DistrictInfo, DistrictLockData, CityData } from '../../features/mypage/types';
+import { Spinner } from '../../shared/ui/spinner';
+import { useDistrictStore } from '../../shared/store/district.store';
+
+export const DistrictChoose = () => {
+  const navigate = useNavigate();
+  const [selectedDistricts, setSelectedDistricts] = useState<DistrictInfo[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCity, setSelectedCity] = useState<string>('서울시');
+  const { setSelectedDistricts: setStoreDistricts } = useDistrictStore();
+
+  // 지역구 잠금 상태 조회
+  const { data: districtData, isLoading, isError } = useQuery<DistrictLockData>({
+    queryKey: ['districtLock'],
+    queryFn: async () => {
+      // 실제 API 호출 대신 mock 데이터 사용
+      const mockData = await import('../../features/mypage/mocks/districtLockMock.json');
+      return mockData.data;
+    },
+  });
+
+  // 현재 선택된 도시의 모든 지역구 표시
+  const currentCityData = districtData?.cities.find(city => city.cityName === selectedCity);
+  const allDistricts = currentCityData?.districts || [];
+
+  // 검색 필터링
+  const filteredDistricts = allDistricts.filter(district =>
+    district.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  // 지역구 선택/해제 핸들러
+  const handleDistrictToggle = (district: DistrictInfo) => {
+    setSelectedDistricts(prev => {
+      const isSelected = prev.some(d => d.id === district.id);
+      if (isSelected) {
+        return prev.filter(d => d.id !== district.id);
+      } else if (prev.length < 2) {
+        return [...prev, district];
+      }
+      return prev;
+    });
+  };
+
+  // 다음 단계로 이동
+  const handleNext = () => {
+    if (selectedDistricts.length === 2) {
+      setStoreDistricts(selectedDistricts);
+      navigate('/home/district/check');
+    }
+  };
+
+  if (isLoading) return <Spinner />;
+  if (isError) return <div className="flex justify-center items-center text-red-500">정보를 불러오는데 실패했습니다.</div>;
+
+  return (
+    <div className="flex items-center justify-center w-full h-full">
+      <div className="h-[800px] w-[700px] bg-[#DED6D6] border-gray-300 border rounded-2xl p-4 py-16 flex flex-col gap-4 justify-start items-center">
+        <h1 className="text-2xl font-bold text-gray-800">데이트 지역 선택</h1>
+        <p className="text-gray-600 text-center">함께 데이트하고 싶은 2개의 자치구를 선택해주세요</p>
+        <p className="text-sm text-gray-500 text-center max-w-md">
+          선택한 지역구를 기반으로 맞춤형 데이트 코스를 추천해드립니다
+        </p>
+        
+        {/* 도시 탭 메뉴 */}
+        <div className="flex gap-1 bg-gray-100 rounded-lg p-1 w-full max-w-md">
+          <button
+            onClick={() => setSelectedCity('서울시')}
+            className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
+              selectedCity === '서울시'
+                ? 'bg-white text-primary shadow-sm'
+                : 'text-gray-600 hover:text-gray-800'
+            }`}
+          >
+            서울시
+          </button>
+          <button
+            className="px-4 py-2 rounded-md text-sm font-medium text-gray-400 cursor-not-allowed"
+            disabled
+          >
+            (추후 추가 예정)
+          </button>
+        </div>
+        
+        {/* 선택된 지역구 표시 */}
+        <div className="w-full max-w-md">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-sm text-gray-600">선택된 자치구 ({selectedDistricts.length}/2)</span>
+          </div>
+          <div className="flex gap-2 flex-wrap">
+            {selectedDistricts.map((district) => (
+              <div
+                key={district.id}
+                className="bg-primary text-white px-3 py-1 rounded-full text-sm flex items-center gap-1"
+              >
+                <span>{district.name}</span>
+                <button
+                  onClick={() => handleDistrictToggle(district)}
+                  className="ml-1 hover:bg-white/20 rounded-full p-0.5"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* 검색바 */}
+        <div className="w-full max-w-md">
+          <input
+            type="text"
+            placeholder="자치구 검색..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full h-12 px-4 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-pink-200 focus:border-transparent transition-all duration-200"
+          />
+        </div>
+
+        {/* 자치구 그리드 */}
+        <div className="grid grid-cols-2 gap-3 max-h-80 overflow-y-auto w-full max-w-md">
+          {filteredDistricts.map((district) => {
+            const isSelected = selectedDistricts.some(d => d.id === district.id);
+            const canSelect = selectedDistricts.length < 2 || isSelected;
+            
+            return (
+              <div
+                key={district.id}
+                onClick={() => canSelect && handleDistrictToggle(district)}
+                className={`p-3 rounded-lg border transition-all duration-200 cursor-pointer ${
+                  isSelected
+                    ? 'bg-primary text-white border-primary'
+                    : canSelect
+                    ? 'bg-white border-gray-300 hover:border-primary hover:shadow-md'
+                    : 'bg-gray-100 border-gray-200 cursor-not-allowed opacity-50'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-sm">{district.name}</span>
+                  </div>
+                  {isSelected && (
+                    <FontAwesomeIcon icon={faCheck} className="w-4 h-4 text-white" />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 빈 상태 */}
+        {filteredDistricts.length === 0 && (
+          <div className="text-center py-8 text-gray-500">
+            <FontAwesomeIcon icon={faMapMarkerAlt} className="w-12 h-12 mx-auto mb-4 text-gray-300" />
+            <p>검색 결과가 없습니다.</p>
+          </div>
+        )}
+
+        {/* 다음 버튼 */}
+        <button
+          onClick={handleNext}
+          disabled={selectedDistricts.length !== 2}
+          className={`w-[220px] h-[44px] rounded-md font-medium transition-all duration-200 ${
+            selectedDistricts.length === 2
+              ? 'bg-primary text-white hover:bg-primary/80'
+              : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+          }`}
+        >
+          다음 단계
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/DistrictPage/DistrictModal.tsx
+++ b/src/pages/DistrictPage/DistrictModal.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from "react-router-dom";
+
+export const DistrictModal = () => {
+  return (
+    <div className="fixed top-0 left-0 w-full h-full z-50 bg-black bg-opacity-50">
+      <Outlet />
+    </div>
+  );
+};

--- a/src/pages/DistrictPage/index.ts
+++ b/src/pages/DistrictPage/index.ts
@@ -1,0 +1,3 @@
+export { DistrictModal } from './DistrictModal';
+export { DistrictChoose } from './DistrictChoose';
+export { DistrictCheck } from './DistrictCheck';

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -4,10 +4,12 @@ import { Button } from "../../shared/ui/button";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { CoupleRoomModal } from "../CoupleRoomPage/CoupleRoomModal";
+import { DistrictModal } from "../DistrictPage/DistrictModal";
 
 export const MainPage = () => {
   const { isMarkers } = useMarkerStore();
   const [isCoupleRoom, setIsCoupleRoom] = useState(false);
+  const [isDistrict, setIsDistrict] = useState(false);
   const [clicked, setClicked] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
@@ -15,8 +17,13 @@ export const MainPage = () => {
   useEffect(() => {
     if (location.pathname.includes("/coupleroom")) {
       setIsCoupleRoom(true);
+      setIsDistrict(false);
+    } else if (location.pathname.includes("/district")) {
+      setIsDistrict(true);
+      setIsCoupleRoom(false);
     } else {
       setIsCoupleRoom(false);
+      setIsDistrict(false);
     }
   }, [location.pathname]);
   
@@ -62,6 +69,9 @@ export const MainPage = () => {
       </div>
       {isCoupleRoom && (
         <CoupleRoomModal />
+      )}
+      {isDistrict && (
+        <DistrictModal />
       )}
     </div>
   );

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,5 +1,6 @@
 import { Profile } from "../../features/mypage/components/Profile";
 import { CoupleHome } from "../../features/mypage/components/CoupleHome";
+import { DistrictLock } from "../../features/mypage/components/DistrictLock";
 import { PersonalOnboarding } from "../../features/onboarding/PersonalOnboarding";
 import { useHeaderStore } from "../../shared/store/header.store";
 import { useMypageStore } from "../../shared/store/mypage.store";
@@ -122,50 +123,58 @@ export const MyPage = () => {
   return (
     <div
       className="
-        flex flex-col 2xl:flex-row gap-8 2xl:gap-4 items-center justify-start py-10 bg-primary/5
+        flex flex-col gap-8 items-center justify-start py-10 bg-primary/5
         w-full h-full min-h-screen
         2xl:px-20 2xl:items-start
         px-0
       ">
-      {/* 왼쪽 섹션 */}
-      <div className={`flex flex-col gap-8 w-full ${isOpen ? "min-w-[720px] max-w-[720px]" : "min-w-[720px] max-w-[720px] 2xl:min-w-[720px] 2xl:max-w-[850px]"}`
-      }>
-
-        {/* 개인 온보딩 카드 */}
-        <div className="p-8 px-2 md:px-0 border border-primary/10 rounded-2xl shadow-sm bg-white/80 backdrop-blur-sm transition-all hover:shadow-md">
-          <h2 className="text-2xl mb-4 text-gray-800 px-2 md:px-8">개인 온보딩</h2>
-          {isProfileLoading && <Spinner />}
-          {!isProfileLoading && !isProfileError && (
-          <>
-            <PersonalOnboarding />
-            <div className="flex justify-end mt-12 px-8">
-              <div className="bg-third/60 text-white w-[120px] h-[40px] text-center py-2 rounded-md cursor-pointer border border-primary/10 text-gray-500 mt-4 hover:bg-third/80 transition-all duration-300"
-                onClick={handleSubmit}
-              >
-                {putMypage.isPending ? '저장하는 중...' : "저장"}
+      {/* 상단 2단 레이아웃 */}
+      <div className="flex flex-col 2xl:flex-row gap-8 2xl:gap-4 w-full">
+        {/* 왼쪽 섹션 - 개인 온보딩 */}
+        <div className={`flex flex-col gap-8 w-full ${isOpen ? "min-w-[720px] max-w-[720px]" : "min-w-[720px] max-w-[720px] 2xl:min-w-[720px] 2xl:max-w-[850px]"}`
+        }>
+          <div className="p-8 px-2 md:px-0 border border-primary/10 rounded-2xl shadow-sm bg-white/80 backdrop-blur-sm transition-all hover:shadow-md">
+            <h2 className="text-2xl mb-4 text-gray-800 px-2 md:px-8">개인 온보딩</h2>
+            {isProfileLoading && <Spinner />}
+            {!isProfileLoading && !isProfileError && (
+            <>
+              <PersonalOnboarding />
+              <div className="flex justify-end mt-12 px-8">
+                <div className="bg-third/60 text-white w-[120px] h-[40px] text-center py-2 rounded-md cursor-pointer border border-primary/10 text-gray-500 mt-4 hover:bg-third/80 transition-all duration-300"
+                  onClick={handleSubmit}
+                >
+                  {putMypage.isPending ? '저장하는 중...' : "저장"}
+                </div>
               </div>
-            </div>
-          </>
-          )}
+            </>
+            )}
+          </div>
+        </div>
+
+        {/* 오른쪽 섹션 - 프로필 정보 & 커플 홈 */}
+        <div className={`flex flex-col gap-8 w-full ${isOpen ? "min-w-[400px] max-w-[720px]" : "min-w-[720px] max-w-[720px] 2xl:max-w-[850px] 2xl:min-w-[400px]"}`
+        }>
+          {/* 프로필 카드 */}
+          <div className="p-8 border border-primary/10 rounded-2xl shadow-sm bg-white/80 backdrop-blur-sm transition-all hover:shadow-md">
+            <Profile />
+          </div>
+          {/* 커플 홈 섹션 */}
+          <div className={`
+            flex flex-col justify-center items-center w-full px-2 md:px-0
+            2xl:max-h-[600px]
+            border border-primary/10 rounded-2xl shadow-sm bg-white/80 
+            backdrop-blur-sm p-6 transition-all hover:shadow-md
+            ${isOpen ? "min-w-[720px] max-w-[720px] 2xl:max-w-[720px] 2xl:min-w-[400px]" : "min-w-[720px] max-w-[720px] 2xl:max-w-[850px] 2xl:min-w-[400px]"}
+          `}>
+            <CoupleHome />
+          </div>
         </div>
       </div>
 
-      {/* 왼쪽 섹션 */}
-      <div className={`flex flex-col gap-8 w-full ${isOpen ? "min-w-[400px] max-w-[720px]" : "min-w-[720px] max-w-[720px] 2xl:max-w-[850px] 2xl:min-w-[400px]"}`
-      }>
-        {/* 프로필 카드 */}
-        <div className="p-8 border border-primary/10 rounded-2xl shadow-sm bg-white/80 backdrop-blur-sm transition-all hover:shadow-md">
-          <Profile />
-        </div>
-        {/* 커플 홈 섹션 */}
-        <div className={`
-          flex flex-col justify-center items-center w-full px-2 md:px-0
-          2xl:max-h-[600px]
-          border border-primary/10 rounded-2xl shadow-sm bg-white/80 
-          backdrop-blur-sm p-6 transition-all hover:shadow-md
-          ${isOpen ? "min-w-[720px] max-w-[720px] 2xl:max-w-[720px] 2xl:min-w-[400px]" : "min-w-[720px] max-w-[720px] 2xl:max-w-[850px] 2xl:min-w-[400px]"}
-        `}>
-          <CoupleHome />
+      {/* 하단 - 지역구 잠금 시스템 */}
+      <div className="w-full">
+        <div className="border border-primary/10 rounded-2xl shadow-sm bg-white/80 backdrop-blur-sm transition-all hover:shadow-md">
+          <DistrictLock />
         </div>
       </div>
     </div>

--- a/src/shared/store/district.store.ts
+++ b/src/shared/store/district.store.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import { DistrictInfo } from "../../features/mypage/types";
+
+export interface DistrictStore {
+  selectedDistricts: DistrictInfo[];
+  setSelectedDistricts: (districts: DistrictInfo[]) => void;
+  clearSelectedDistricts: () => void;
+}
+
+export const useDistrictStore = create<DistrictStore>((set) => ({
+  selectedDistricts: [],
+  setSelectedDistricts: (districts: DistrictInfo[]) => set({ selectedDistricts: districts }),
+  clearSelectedDistricts: () => set({ selectedDistricts: [] }),
+}));


### PR DESCRIPTION
## 개요
커플 인증 완료 후 데이트 지역 선택 기능을 추가했습니다. 사용자가 2개의 자치구를 선택하여 맞춤형 데이트 코스 추천을 받을 수 있도록 하는 새로운 플로우를 구현했습니다.

## PR 유형

- [x] 새로운 기능 추가

## PR Checklist

- [x] merge branch 가 develop 인지 확인
- [x] 모든 코드가 잘 작동하는지 확인
- [x] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 기타
커플룸과 동일한 모달 디자인 적용
잠금 상태와 무관하게 자유로운 지역 선택 가능
도시 탭 메뉴로 확장성 고려 (서울시 외 추후 추가 예정)
