### PR TITLE
[FIX] separate init unlock and reward unlock API endpoints - PIT-628

### DIFF
--- a/src/features/district/api.ts
+++ b/src/features/district/api.ts
@@ -1,6 +1,9 @@
 import { api } from "../../shared/api/base";
 
 export const districtApi = {
-  unlockDistrict: (regions: string[]) => api.post(`/api/regions/unlock`, { regions }),
+  // 초기 지역락 해제 (처음 2개 지역 선택)
+  initUnlockDistrict: (regions: string[]) => api.post(`/api/regions/unlock/init`, { regions }),
+  // 티켓으로 지역락 해제 (추가 지역 해제)
+  rewardUnlockDistrict: (regions: string[]) => api.post(`/api/regions/unlock/reward`, { regions }),
   getDistrictLock: () => api.get('/api/regions/search'),
 };

--- a/src/features/district/components/DistrictLock.tsx
+++ b/src/features/district/components/DistrictLock.tsx
@@ -27,9 +27,9 @@ export const DistrictLock = () => {
     },
   });
 
-  // 지역구 잠금 해제 mutation
+  // 지역구 잠금 해제 mutation (티켓 해금)
   const unlockDistrictMutation = useMutation({
-    mutationFn: (regions: string[]) => districtApi.unlockDistrict(regions),
+    mutationFn: (regions: string[]) => districtApi.rewardUnlockDistrict(regions),
     onSuccess: (_, regions) => {
       toast.success('지역구 잠금이 해제되었습니다!');
       setUnlockingDistricts(prev => {

--- a/src/pages/DistrictPage/DistrictCheck.tsx
+++ b/src/pages/DistrictPage/DistrictCheck.tsx
@@ -14,11 +14,11 @@ export const DistrictCheck = () => {
   const { selectedDistricts, clearSelectedDistricts } = useDistrictStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // 지역구 선택 확인 API 호출
+  // 지역구 선택 확인 API 호출 (초기 해금)
   const confirmDistrictMutation = useMutation({
     mutationFn: async (districtNames: string[]) => {
       console.log(districtNames);
-      const response = await districtApi.unlockDistrict(districtNames);
+      const response = await districtApi.initUnlockDistrict(districtNames);
       return response;
     },
     onSuccess: () => {


### PR DESCRIPTION
- Add initUnlockDistrict for initial region selection (/unlock/init)
- Add rewardUnlockDistrict for ticket-based unlock (/unlock/reward)
- Update DistrictCheck to use init unlock API
- Update DistrictLock to use reward unlock API
- Fix API routing to match backend service architecture

This ensures proper API separation:
- Initial region unlock: Territory Service ↔ Auth Service (internal communication)
- Reward unlock: Gateway → Auth Service → Territory Service (with ticket management)
- Prevents 403 Forbidden errors by using correct endpoints

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] merge branch 가 develop 인지 확인
- [ ] 모든 코드가 잘 작동하는지 확인
- [x] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 기타
